### PR TITLE
Compatible version of Connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines" : ["node"],
   "repository" : { "type":"git", "url":"http://github.com/mape/node-express-boilerplate" },
   "dependencies" : {
-    "connect" : ">=1.6.0",
+    "connect" : "1.8.7",
     "connect-assetmanager" : ">=0.0.21",
     "connect-assetmanager-handlers" : ">=0.0.17",
     "ejs" : ">=0.4.3",


### PR DESCRIPTION
I was getting this error, caused by installing the latest version of connect:
Caught exception: TypeError: undefined is not a function
TypeError: undefined is not a function
    at Manager.<anonymous> (/Users/aswan/myproject/lib/socket-io-server.js:10:17)
    at Manager.authorize (/Users/aswan/myproject/node_modules/socket.io/lib/manager.js:867:31)
    at Manager.handleHandshake (/Users/aswan/myproject/node_modules/socket.io/lib/manager.js:743:8)
    at Manager.handleRequest (/Users/aswan/myproject/node_modules/socket.io/lib/manager.js:570:12)
    at HTTPServer.<anonymous> (/Users/aswan/myproject/node_modules/socket.io/lib/manager.js:116:10)
    at HTTPServer.emit (events.js:70:17)
    at HTTPParser.onIncoming (http.js:1514:12)
    at HTTPParser.onHeadersComplete (http.js:102:31)
    at Socket.ondata (http.js:1410:22)
    at TCP.onread (net.js:354:27)

This error does not occur when you use a version of Connect < 2.0.  I have updated the package.json to use version 1.8.7
