### PR TITLE
Update with h5bp

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -5,8 +5,8 @@
 <!--[if IE 9 ]> <html class="ie9 ie nojs"> <![endif]--> 
 <!--[if !IE]><!--> <html class="nojs"> <!--<![endif]-->
 <head>
+	<meta charset="utf-8">
 	<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<link rel="stylesheet" href="/static/css/<%=assetsCacheHashes.css||0%>/style.css" type="text/css">
 	<title>node-express-boilerplate</title>
 </head>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -5,7 +5,7 @@
 <!--[if IE 9 ]> <html class="ie9 ie nojs"> <![endif]--> 
 <!--[if !IE]><!--> <html class="nojs"> <!--<![endif]-->
 <head>
-	<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><![endif]-->
+	<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<link rel="stylesheet" href="/static/css/<%=assetsCacheHashes.css||0%>/style.css" type="text/css">
 	<title>node-express-boilerplate</title>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--[if lt IE 7 ]> <html class="ie6 ie nojs"> <![endif]--> 
 <!--[if IE 7 ]> <html class="ie7 ie nojs"> <![endif]--> 
 <!--[if IE 8 ]> <html class="ie8 ie nojs"> <![endif]--> 


### PR DESCRIPTION
1. Uppercase doctypes don't make sense. It's just inconsistent with the other tags. https://github.com/h5bp/html5-boilerplate/commit/e2a3080a310630315b4f17b2bf4f63c68f78f805
2. Chrome frame is deprecated. https://github.com/h5bp/server-configs-apache/commit/fa5d08c2867740832a480e601c290c7b265fb047
3. The old charset declaration is just a wast of bytes. Also, it must be the first thing in the `<head>`.
